### PR TITLE
メンションに含まれるユーザー名を読み上げるようにした

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -43,7 +43,7 @@ async def on_message(message:discord.Message):
         and type(message.guild.voice_client) is discord.VoiceClient
         and message.guild.voice_client.is_connected()
     ):
-        buf = await voicevox.genarete_sound(text=preprocess_text(message.content))
+        buf = await voicevox.genarete_sound(text=preprocess_text(message.content), guild=message.guild)
         if buf is None:
             await message.reply('audio failed')
             return

--- a/src/voicevox.py
+++ b/src/voicevox.py
@@ -2,13 +2,24 @@ import aiohttp
 import json
 from io import BytesIO
 from dataclasses import dataclass
+import re
+from discord.message import Guild
 
 @dataclass
 class Voicevox:
     host: str
     port: int
 
-    async def genarete_sound(self, text: str, speaker=1, speed=100, pitch=0) -> BytesIO | None:
+    async def genarete_sound(self, text: str, guild: Guild, speaker=1, speed=100, pitch=0) -> BytesIO | None:
+        # Mention先のUserID取得
+        mention_id = re.search('[0-9]+', text)
+        if mention_id is not None:
+            member = guild.get_member(int(mention_id.group()))
+            if member is not None:
+                user_name = member.display_name
+                # @{user_id} を @{display_name}さん に置き換える
+                text = text.replace(mention_id.group(), user_name + 'さん')
+
         params = (
             ('text', text),
             ('speaker', speaker),


### PR DESCRIPTION
# 対象Issue

#15 

## 対応内容

`@hogehoge sample text` と送ったテキストを、`@{user_id} sample text` と読み上げてしまうため、
`@{user_name}さん sample text` という形式で読み上げるよう改修を行った

## 想定される挙動

`@hogehoge sample text` とメンションを送った際に、 `@{user_name}さん sample text` と読み上げること

## 参考にしたとこ

グローバル名ではなく、サーバープロフィール名で取得したかったので、以下を参考に実装を行った。

https://github.com/Rapptz/discord.py/issues/1256