### PR TITLE
#24 BlackFormatterを推奨拡張機能に設定。また、デフォルトフォーマッタに指定

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-python.black-formatter"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
   "python.linting.mypyEnabled": true,
-  "python.linting.enabled": true
+  "python.linting.enabled": true,
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true
+  },
 }


### PR DESCRIPTION
## 概要

[BlackFormatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter)を、VSCode環境におけるmurmurワークスペースにて以下の対応を行いました。

- 推奨拡張機能に指定
- Pythonファイルでのデフォルトフォーマッタに設定
- ファイル保存時にフォーマットがかかる設定を有効化


## 変更点

- extensions.jsonを新規追加
- settings.jsonで、デフォルトフォーマッタをBlackFormatterを指定
- settings.jsonで、保存時フォーマットを有効化

## 影響範囲

BlackFormatterを指定することにより、既存ファイルの保存時にフォーマットがかかり大きくレイアウトが変わります。

## テスト

- VSCodeのExtensionsで `@recommended` と入力すると Black Formatter が表示されること
- Black Formatterインストール後、Pythonファイルで保存時にフォーマットがかかること

## 関連Issue

- #18
- #24 