### PR TITLE
長い文章の省略

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "ms-python.black-formatter"
+        "ms-python.black-formatter",
+        "ms-python.mypy-type-checker"
     ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ mypy~=1.5.1
 requests~=2.31
 types-requests~=2.31
 psutil~=5.9.6
+types-psutil~=5.9.5.17

--- a/src/SynthesisRunner.py
+++ b/src/SynthesisRunner.py
@@ -6,7 +6,6 @@ from typing import Callable, Coroutine
 from concurrent.futures import ThreadPoolExecutor
 import asyncio
 from asyncio import AbstractEventLoop, Task
-import math
 
 
 @dataclass

--- a/src/bot.py
+++ b/src/bot.py
@@ -25,7 +25,7 @@ voice_queue = Text2SpeechQueue(bot, voicevox)
 
 @bot.event
 async def on_ready():
-    print(f"Logged in as {bot.user} (ID: {bot.user.id})")
+    print(f"Logged in as {bot.user} (ID: {bot.user.id if bot.user else 'user None'})")
     print("------")
     await bot.tree.sync()
     voice_queue.run()

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -57,12 +57,22 @@ def preprocess_alphabet(text: str):
     )
 
 
+def preprocess_omission_long_text(text: str):
+    # この長さ以下は省略
+    omission_length = 40
+    if len(text) > omission_length:
+        return text[:omission_length] + "以下略"
+    else:
+        return text
+
+
 def preprocess_text(text: str):
     processors = [
         preprocess_url,
         preprocess_emoji,
         preprocess_dup_consonant_alphabet,
         preprocess_alphabet,
+        preprocess_omission_long_text,
     ]
 
     return reduce(lambda p, c: c(p), processors, text)

--- a/src/textToSpeechQueue.py
+++ b/src/textToSpeechQueue.py
@@ -59,7 +59,7 @@ class Text2SpeechQueue:
             await asyncio.sleep(0.05)
 
             task = self.shift()
-            if task is not None:
+            if task and task.guild:
                 if task.source and type(task.guild.voice_client) is discord.VoiceClient:
                     task.guild.voice_client.play(task.source, after=after_fn)
                 else:

--- a/src/voicevox.py
+++ b/src/voicevox.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 from dataclasses import dataclass
 import re
-from discord.message import Guild
+from discord.guild import Guild
 import os
 from os import path
 import asyncio


### PR DESCRIPTION
## 概要

長い文章の読み上げを省略するようにしました。  
40文字以上の文章は省略し「以下略」と付け足すようにしました。

## 変更点

- preprocessに40文字以上のテキストを省略する処理を追加

## 影響範囲

- preprocess以降の読み上げ処理

## テスト

## 関連Issue

- 関連Issue: #9 