### PR TITLE
セミコロンで始まる行を無視する機能の追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ requests~=2.31
 types-requests~=2.31
 psutil~=5.9.6
 types-psutil~=5.9.5.17
+pytest~=7.4.2

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1,6 +1,7 @@
 import re, json
 from os import path
 from functools import reduce
+from sys import prefix
 
 
 def load_romanization_table(paths: list[str]):
@@ -66,12 +67,24 @@ def preprocess_omission_long_text(text: str):
         return text
 
 
+# ;(セミコロン)で始まる行を省略
+def preprocess_ignore_line(text: str):
+    prefix_char = ";"
+    lines = text.split("\n")  # テキストを行に分割
+    filtered_lines = [
+        line for line in lines if not line.strip().startswith(prefix_char)
+    ]
+    result = "\n".join(filtered_lines)  # 行を再結合してテキストに戻す
+    return result
+
+
 def preprocess_text(text: str):
     processors = [
         preprocess_url,
         preprocess_emoji,
         preprocess_dup_consonant_alphabet,
         preprocess_alphabet,
+        preprocess_ignore_line,
         preprocess_omission_long_text,
     ]
 

--- a/src/tests/test_preprocessor.py
+++ b/src/tests/test_preprocessor.py
@@ -1,0 +1,34 @@
+import pytest
+from preprocessor import preprocess_ignore_line
+
+
+@pytest.mark.parametrize(
+    "input_string, expected_output",
+    [
+        (
+            """
+            これはテストです
+            ; この行は無視します
+            ; この行は無視します
+            この行は読み上げます
+            ; この行は無視します
+            """,
+            """
+            これはテストです
+            この行は読み上げます
+            """,
+        ),
+        (
+            """
+            ;先頭を無視するテストです
+            この行は読み上げます
+            """,
+            """
+            この行は読み上げます
+            """,
+        ),
+    ],
+)
+def test_preprocess_ignore_line(input_string, expected_output):
+    output_string = preprocess_ignore_line(input_string)
+    assert output_string == expected_output


### PR DESCRIPTION
## 概要

セミコロンで始まる行の読み上げを無視するようにしました。
ついでにpytestも導入してテストを書いてみました。

## 変更点

- preprocessor関数の追加
- testsフォルダの追加
- pytestのパッケージの追加

## 影響範囲

preprocess以降の処理。

## テスト
```
(
    """
    これはテストです
    ; この行は無視します
    ; この行は無視します
    この行は読み上げます
    ; この行は無視します
    """,
    """
    これはテストです
    この行は読み上げます
    """,
),
(
    """
    ;先頭を無視するテストです
    この行は読み上げます
    """,
    """
    この行は読み上げます
    """,
),
```
のパターンでテストしました

## 関連Issue

- 関連Issue: #38 